### PR TITLE
Add FastAPI backend for season tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+data.db
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # cartoon-hero
-super hero
+
+This project provides a minimal FastAPI backend and simple interface for tracking a FIFA-style league season, players and match results.
+
+## Development
+
+Create a virtual environment and install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Run the API locally:
+
+```bash
+uvicorn app:app --reload
+```
+
+Interactive docs are available at <http://127.0.0.1:8000/docs>.
+
+## Testing
+
+```bash
+pytest
+```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,33 @@
+from typing import List
+from fastapi import FastAPI
+from database import init_db, add_player, list_players, record_match, get_season
+from schemas import PlayerCreate, Player, MatchCreate, Season
+
+# initialize database on startup
+init_db()
+
+app = FastAPI(title="Cartoon Hero Tracker")
+
+
+@app.post("/players", response_model=Player)
+def create_player(player: PlayerCreate):
+    player_id = add_player(
+        player.name, player.rating, player.nationality, player.homegrown
+    )
+    return Player(id=player_id, **player.dict())
+
+
+@app.get("/players", response_model=List[Player])
+def get_players():
+    return [Player(**p) for p in list_players()]
+
+
+@app.post("/matches", response_model=Season)
+def add_match(match: MatchCreate):
+    record_match(match.result)
+    return Season(**get_season())
+
+
+@app.get("/season", response_model=Season)
+def season_status():
+    return Season(**get_season())

--- a/database.py
+++ b/database.py
@@ -1,0 +1,108 @@
+"""Simple SQLite backend for tracking squad and season data."""
+import sqlite3
+from pathlib import Path
+from typing import List, Dict, Any
+
+DB_PATH = Path(__file__).with_name("data.db")
+
+
+def get_connection():
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_db() -> None:
+    """Initialise all tables and ensure a season row exists."""
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS players (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            rating INTEGER NOT NULL,
+            nationality TEXT NOT NULL,
+            homegrown INTEGER NOT NULL DEFAULT 0,
+            matches_played INTEGER NOT NULL DEFAULT 0,
+            injury_games_remaining INTEGER NOT NULL DEFAULT 0
+        );
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS season (
+            id INTEGER PRIMARY KEY CHECK(id = 1),
+            games_played INTEGER NOT NULL DEFAULT 0,
+            points INTEGER NOT NULL DEFAULT 0,
+            rating_cap INTEGER NOT NULL DEFAULT 60,
+            budget INTEGER NOT NULL DEFAULT 0
+        );
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS matches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            result TEXT NOT NULL CHECK(result IN ('W','D','L')),
+            season_id INTEGER NOT NULL,
+            FOREIGN KEY(season_id) REFERENCES season(id)
+        );
+        """
+    )
+    # ensure a season row exists
+    cur.execute("INSERT OR IGNORE INTO season(id) VALUES (1)")
+    conn.commit()
+    conn.close()
+
+
+def add_player(name: str, rating: int, nationality: str, homegrown: bool) -> int:
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO players(name, rating, nationality, homegrown) VALUES (?,?,?,?)",
+        (name, rating, nationality, int(homegrown)),
+    )
+    conn.commit()
+    player_id = cur.lastrowid
+    conn.close()
+    return player_id
+
+
+def list_players() -> List[Dict[str, Any]]:
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT * FROM players")
+    rows = cur.fetchall()
+    conn.close()
+    return [dict(row) for row in rows]
+
+
+def record_match(result: str) -> None:
+    points_map = {"W": 3, "D": 1, "L": 0}
+    if result not in points_map:
+        raise ValueError("result must be one of 'W', 'D' or 'L'")
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO matches(result, season_id) VALUES (?, 1)", (result,)
+    )
+    cur.execute(
+        "UPDATE season SET games_played = games_played + 1, points = points + ? WHERE id = 1",
+        (points_map[result],),
+    )
+    conn.commit()
+    conn.close()
+
+
+def get_season() -> Dict[str, Any]:
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT games_played, points, rating_cap, budget FROM season WHERE id=1")
+    row = cur.fetchone()
+    conn.close()
+    return dict(row)
+
+
+if __name__ == "__main__":
+    init_db()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+
+httpx

--- a/schemas.py
+++ b/schemas.py
@@ -1,0 +1,33 @@
+from pydantic import BaseModel
+from typing import List
+
+
+class PlayerCreate(BaseModel):
+    name: str
+    rating: int
+    nationality: str
+    homegrown: bool = False
+
+
+class Player(PlayerCreate):
+    id: int
+    matches_played: int = 0
+    injury_games_remaining: int = 0
+
+    class Config:
+        orm_mode = True
+
+
+class MatchCreate(BaseModel):
+    result: str  # 'W', 'D', 'L'
+
+
+class Season(BaseModel):
+    games_played: int
+    points: int
+    rating_cap: int
+    budget: int
+
+
+class PlayerList(BaseModel):
+    players: List[Player]

--- a/test_app.py
+++ b/test_app.py
@@ -1,0 +1,41 @@
+import os
+import json
+from fastapi.testclient import TestClient
+
+# ensure a fresh database for tests
+if os.path.exists("data.db"):
+    os.remove("data.db")
+
+from app import app
+
+client = TestClient(app)
+
+
+def test_create_player_and_record_match():
+    resp = client.post(
+        "/players",
+        json={"name": "John", "rating": 55, "nationality": "ENG", "homegrown": True},
+    )
+    assert resp.status_code == 200
+    player = resp.json()
+    assert player["name"] == "John"
+    assert player["homegrown"] is True
+
+    resp = client.post("/matches", json={"result": "W"})
+    assert resp.status_code == 200
+    season = resp.json()
+    assert season["games_played"] == 1
+    assert season["points"] == 3
+
+
+def test_get_players_and_season():
+    resp = client.get("/players")
+    assert resp.status_code == 200
+    players = resp.json()
+    assert len(players) >= 1
+
+    resp = client.get("/season")
+    assert resp.status_code == 200
+    season = resp.json()
+    assert "games_played" in season
+    assert "points" in season


### PR DESCRIPTION
## Summary
- implement FastAPI app with endpoints for players, matches and season status
- add SQLite database helper and Pydantic schemas
- document usage and add tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc68856088832290c477164c25938b